### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/KHolodilin/mgt7-pdf-to-json/security/code-scanning/5](https://github.com/KHolodilin/mgt7-pdf-to-json/security/code-scanning/5)

To fix this, explicitly restrict the `GITHUB_TOKEN` permissions for the workflow to the minimal set required. The jobs here only need to read repository contents and work with artifacts; none of them push code, create releases, or modify issues, so `contents: read` is sufficient for all jobs, including `publish`.

The best fix, without changing behavior, is to add a root-level `permissions:` block (applies to all jobs that don’t override it) directly under the existing `name: CI` line in `.github/workflows/ci.yml`:

- Set `permissions: contents: read` at the workflow level.
- Do not add any write permissions, since they are not needed by the shown steps.
- No other changes, imports, or dependencies are necessary.

Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
name: CI
permissions:
  contents: read
```

above the existing `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
